### PR TITLE
Fixed MSVC build issue for 4.3 stable

### DIFF
--- a/thirdparty/thorvg/src/common/tvgLock.h
+++ b/thirdparty/thorvg/src/common/tvgLock.h
@@ -25,8 +25,6 @@
 
 #ifdef THORVG_THREAD_SUPPORT
 
-#define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
-
 #include <mutex>
 #include "tvgTaskScheduler.h"
 

--- a/thirdparty/thorvg/src/renderer/tvgTaskScheduler.h
+++ b/thirdparty/thorvg/src/renderer/tvgTaskScheduler.h
@@ -23,8 +23,6 @@
 #ifndef _TVG_TASK_SCHEDULER_H_
 #define _TVG_TASK_SCHEDULER_H_
 
-#define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
-
 #include <mutex>
 #include <condition_variable>
 


### PR DESCRIPTION
Removed #define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
from tvgLock and tvgTaskScheduler as instructed
by https://github.com/godotengine/godot/issues/95861#issuecomment-2498434206

This fix is **only needed for 4.3 stable** (tag, which will never receive further updates). Later releases have it already fixed.